### PR TITLE
Error writing to ES, error_xml field is too long

### DIFF
--- a/Elmah.Io.ElasticSearch/ErrorDocument.cs
+++ b/Elmah.Io.ElasticSearch/ErrorDocument.cs
@@ -8,7 +8,7 @@ namespace Elmah.Io.ElasticSearch
     {
         public string Id { get; set; }
 
-        [ElasticProperty(Index = FieldIndexOption.NotAnalyzed)]
+        [ElasticProperty(Index = FieldIndexOption.No)]
         public string ErrorXml { get; set; }
 
         [ElasticProperty(Index = FieldIndexOption.NotAnalyzed)]


### PR DESCRIPTION
IllegalArgumentException[Document contains at least one immense term in field=\"error_xml\"

From this link here I believe we just need to set the index on ErrorXml from "NotAlalyzed" to "No"

http://stackoverflow.com/questions/24019868/utf8-encoding-is-longer-than-the-max-length-32766
