### PR TITLE
Do not load the error log config section again

### DIFF
--- a/Elmah.Io.ElasticSearch/ElasticClientSingleton.cs
+++ b/Elmah.Io.ElasticSearch/ElasticClientSingleton.cs
@@ -18,9 +18,13 @@ namespace Elmah.Io.ElasticSearch
         private static ElasticClientSingleton _instance;
         public IElasticClient Client;
 
-        private ElasticClientSingleton()
+        private ElasticClientSingleton(IDictionary config = null)
         {
-            var config = ReadConfig();
+            if(ReferenceEquals(config, null))
+            {
+                config = ReadConfig();
+            }
+
             var url = LoadConnectionString(config);
             var defaultIndex = GetDefaultIndex(config, url);
             var conString = RemoveDefaultIndexFromConnectionString(url);
@@ -33,9 +37,9 @@ namespace Elmah.Io.ElasticSearch
             }
         }
 
-        public static ElasticClientSingleton Instance
+        public static ElasticClientSingleton GetInstance(IDictionary config)
         {
-            get { return _instance ?? (_instance = new ElasticClientSingleton()); }
+            return _instance ?? (_instance = new ElasticClientSingleton(config));
         }
 
         private void InitIndex(string defaultIndex)

--- a/Elmah.Io.ElasticSearch/ElasticSearchErrorLog.cs
+++ b/Elmah.Io.ElasticSearch/ElasticSearchErrorLog.cs
@@ -20,7 +20,7 @@ namespace Elmah.Io.ElasticSearch
         {
             InitializeConfigParameters(config);
 
-            _elasticClient = ElasticClientSingleton.Instance.Client;
+            _elasticClient = ElasticClientSingleton.GetInstance(config).Client;
         }
 
         /// <summary>


### PR DESCRIPTION
I'm writing a new Error Logger for elmah that tries to log to various Error Loggers.
The use case is for this new Error Logger to not loose logs if for any reason the Elasticsearch is down or unreachable. In that case, it will try to log with another Logger.

So, my Logger will be responsible for loading all the other Logger's, but unfortunately your reads the config section even after you received this config.

So in order for my Logger to work I needed you not to read the config again, but rather use the one that you already have.