### PR TITLE
Remove JetBrains.Annotations Reference

### DIFF
--- a/src/Elmah.Io.ElasticSearch/Elmah.Io.ElasticSearch.csproj
+++ b/src/Elmah.Io.ElasticSearch/Elmah.Io.ElasticSearch.csproj
@@ -42,10 +42,6 @@
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=10.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\packages\NEST.2.4.5\lib\net46\Nest.dll</HintPath>
       <Private>True</Private>

--- a/src/Elmah.Io.ElasticSearch/ExtensionMethods.cs
+++ b/src/Elmah.Io.ElasticSearch/ExtensionMethods.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Elasticsearch.Net;
-using JetBrains.Annotations;
 using Nest;
 
 namespace Elmah.Io.ElasticSearch
@@ -42,8 +40,7 @@ namespace Elmah.Io.ElasticSearch
         /// </summary>
         /// <param name="obj"></param>
         /// <param name="paramName"></param>
-        [ContractAnnotation("obj:null => halt")]
-        public static void ThrowIfNull<T>([NoEnumeration] this T obj, string paramName) where T : class
+        public static void ThrowIfNull<T>(this T obj, string paramName) where T : class
         {
             if (obj == null)
             {

--- a/src/Elmah.Io.ElasticSearch/packages.config
+++ b/src/Elmah.Io.ElasticSearch/packages.config
@@ -3,7 +3,6 @@
   <package id="Elasticsearch.Net" version="2.4.5" targetFramework="net461" />
   <package id="elmah" version="1.2.2" targetFramework="net40" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net40" />
-  <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net40" />
   <package id="NEST" version="2.4.5" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
 </packages>

--- a/src/examples/WebWithExternalReferences/WebWithExternalReferences.csproj
+++ b/src/examples/WebWithExternalReferences/WebWithExternalReferences.csproj
@@ -52,8 +52,8 @@
       <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Elmah.Io.ElasticSearch, Version=2.0.0.35, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elmah.ElasticSearch.2.0.0.35-prerelease\lib\net461\Elmah.Io.ElasticSearch.dll</HintPath>
+    <Reference Include="Elmah.Io.ElasticSearch, Version=2.0.0.45, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Elmah.ElasticSearch.2.0.0.45\lib\net461\Elmah.Io.ElasticSearch.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="JetBrains.Annotations, Version=10.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">

--- a/src/examples/WebWithExternalReferences/packages.config
+++ b/src/examples/WebWithExternalReferences/packages.config
@@ -3,7 +3,7 @@
   <package id="Elasticsearch.Net" version="2.4.5" targetFramework="net461" />
   <package id="elmah" version="1.2.2" targetFramework="net461" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net461" />
-  <package id="Elmah.ElasticSearch" version="2.0.0.35-prerelease" targetFramework="net461" />
+  <package id="Elmah.ElasticSearch" version="2.0.0.45" targetFramework="net461" />
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights" version="2.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net452" />

--- a/src/testing/Elmah.Io.ElasticSearch.Tests/Elmah.Io.ElasticSearch.Tests.csproj
+++ b/src/testing/Elmah.Io.ElasticSearch.Tests/Elmah.Io.ElasticSearch.Tests.csproj
@@ -42,10 +42,6 @@
     <Reference Include="Elmah">
       <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=10.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\JetBrains.Annotations.10.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.1.1309.1617\lib\net40\Moq.dll</HintPath>
     </Reference>

--- a/src/testing/Elmah.Io.ElasticSearch.Tests/packages.config
+++ b/src/testing/Elmah.Io.ElasticSearch.Tests/packages.config
@@ -3,7 +3,6 @@
   <package id="AutoFixture" version="3.12.1" targetFramework="net40" />
   <package id="Elasticsearch.Net" version="2.4.5" targetFramework="net461" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net40" />
-  <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net40" />
   <package id="Moq" version="4.1.1309.1617" targetFramework="net40" />
   <package id="NEST" version="2.4.5" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />


### PR DESCRIPTION
I find it hard to justify dependence on the 58kb `JetBranins.Annotations` library for 2 lines of code that only provide ReSharper support for a consumable library who's consumers may or may not be using ReSharper.

This PR does not resolve the cyclical dependencies from the  `WebWithExternalReferences` project that relies on published code. I did update that projects references to the latest stable version of `Elmah.Io.ElasticSearch`, but it will need to be updated again pending a merge, if approved, to no longer rely on the `JetBrains.Annotations` package.